### PR TITLE
chore: use maxgraph default branch in GH workflows

### DIFF
--- a/.github/workflows/check-typescript-projects.yml
+++ b/.github/workflows/check-typescript-projects.yml
@@ -27,8 +27,6 @@ jobs:
      - uses: actions/checkout@v3
        with:
          repository: 'maxGraph/maxGraph'
-         # branch of the PR that improves the npm package generation: https://github.com/maxGraph/maxGraph/pull/87
-         ref: 'chore/prepare_npm_package'
      - name: Setup node
        uses: actions/setup-node@v3
        with:

--- a/.github/workflows/check-typescript-projects.yml
+++ b/.github/workflows/check-typescript-projects.yml
@@ -32,7 +32,7 @@ jobs:
      - name: Setup node
        uses: actions/setup-node@v3
        with:
-         node-version: '16'
+         node-version-file: '.nvmrc'
      - name: Install dependencies
        run: npm install
      - name: Build package

--- a/projects/parcel-ts/tsconfig.json
+++ b/projects/parcel-ts/tsconfig.json
@@ -13,7 +13,7 @@
     "moduleResolution": "node",
     "noEmit": true, // tsc only used for checks, Parcel manages file generation
     "forceConsistentCasingInFileNames": true,
-    // TODO required as some type definitions in the @maxgraph/core package generate errors
+    // TODO required because some type definitions in the @maxgraph/core package generate errors: https://github.com/maxGraph/maxGraph/issues/96
     "skipLibCheck": true
   },
   "include": [

--- a/projects/rollup-ts/tsconfig.json
+++ b/projects/rollup-ts/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    // TODO required as some type definitions in the @maxgraph/core package generate errors
+    // TODO required because some type definitions in the @maxgraph/core package generate errors: https://github.com/maxGraph/maxGraph/issues/96
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
   },

--- a/projects/vitejs-ts/tsconfig.json
+++ b/projects/vitejs-ts/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    // TODO required as some type definitions in the @maxgraph/core package generate errors
+    // TODO required because some type definitions in the @maxgraph/core package generate errors: https://github.com/maxGraph/maxGraph/issues/96
     "skipLibCheck": true
   },
   "include": ["src"]


### PR DESCRIPTION
Use the maxgraph default branch when building the maxgraph npm package.