### PR TITLE
feat: do not skipLibCheck

### DIFF
--- a/projects/parcel-ts/tsconfig.json
+++ b/projects/parcel-ts/tsconfig.json
@@ -13,8 +13,6 @@
     "moduleResolution": "node",
     "noEmit": true, // tsc only used for checks, Parcel manages file generation
     "forceConsistentCasingInFileNames": true,
-    // TODO required because some type definitions in the @maxgraph/core package generate errors: https://github.com/maxGraph/maxGraph/issues/96
-    "skipLibCheck": true
   },
   "include": [
     "src"

--- a/projects/rollup-ts/tsconfig.json
+++ b/projects/rollup-ts/tsconfig.json
@@ -14,8 +14,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    // TODO required because some type definitions in the @maxgraph/core package generate errors: https://github.com/maxGraph/maxGraph/issues/96
-    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
   },
   "include": ["src"]

--- a/projects/vitejs-ts/tsconfig.json
+++ b/projects/vitejs-ts/tsconfig.json
@@ -14,8 +14,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    // TODO required because some type definitions in the @maxgraph/core package generate errors: https://github.com/maxGraph/maxGraph/issues/96
-    "skipLibCheck": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Types errors in maxGraph has been fixed, so make TypeScript check the types of dependencies.

This was fixed in https://github.com/maxGraph/maxGraph/pull/124