### PR TITLE
chore: bump devDependencies in projects

### DIFF
--- a/projects/parcel-ts/package.json
+++ b/projects/parcel-ts/package.json
@@ -10,7 +10,7 @@
     "@maxgraph/core": "*"
   },
   "devDependencies": {
-    "parcel": "~2.6.0",
-    "typescript": "~4.7.3"
+    "parcel": "~2.7.0",
+    "typescript": "~4.8.4"
   }
 }

--- a/projects/rollup-ts/package.json
+++ b/projects/rollup-ts/package.json
@@ -2,23 +2,23 @@
   "name": "maxgraph-ts-example-built-with-rollup",
   "private": true,
   "version": "0.0.0",
+  "scripts": {
+    "build": "tsc && rollup -c",
+    "watch": "rollup -c -w",
+    "dev": "npm-run-all --parallel start watch",
+    "start": "serve public"
+  },
   "dependencies": {
     "@maxgraph/core": "*"
   },
   "devDependencies": {
-    "@rollup/plugin-node-resolve": "~13.3.0",
+    "@rollup/plugin-node-resolve": "~14.1.0",
     "npm-run-all": "~4.1.5",
-    "rollup": "~2.75.6",
+    "rollup": "~2.79.1",
     "rollup-plugin-terser": "~7.0.2",
     "rollup-plugin-typescript": "~1.0.1",
-    "serve": "~13.0.2",
+    "serve": "~14.0.1",
     "tslib": "~2.4.0",
-    "typescript": "~4.7.3"
-  },
-  "scripts": {
-    "build": "rollup -c",
-    "watch": "rollup -c -w",
-    "dev": "npm-run-all --parallel start watch",
-    "start": "serve public"
+    "typescript": "~4.8.4"
   }
 }

--- a/projects/vitejs-ts/README.md
+++ b/projects/vitejs-ts/README.md
@@ -8,7 +8,7 @@ From the project root, run `npm install`.
 
 See the README about maxGraph integration.
 
-Then, run `npm run dev` and go to http://localhost:3000/
+Then, run `npm run dev` and go to http://localhost:5173/
 
 If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the
 bundle application.

--- a/projects/vitejs-ts/package.json
+++ b/projects/vitejs-ts/package.json
@@ -11,7 +11,7 @@
     "@maxgraph/core": "*"
   },
   "devDependencies": {
-    "typescript": "~4.7.3",
-    "vite": "~2.9.10"
+    "typescript": "~4.8.4",
+    "vite": "~3.1.6"
   }
 }


### PR DESCRIPTION
For rollup, also add types check as part of the 'build' script